### PR TITLE
multiple changes:

### DIFF
--- a/dist/chinchilla.d.ts
+++ b/dist/chinchilla.d.ts
@@ -1,11 +1,3 @@
 import { Subject } from './chinchilla/subject';
-import { Config } from './chinchilla/config';
-import { Context } from './chinchilla/context';
-export default class chch {
-    static subject(objectsOrApp: any, model?: any): Subject;
-    static config: typeof Config;
-    static new(app: any, model: any, attrs?: {}): any;
-    static contextUrl(app: any, model: any): string;
-    static context(urlOrApp: any, model: any): Promise<Context>;
-    static unfurl: (app: any, model: any, actionName: any, params: any) => Promise<{}>;
-}
+declare let chch: (objectsOrApp: any, model?: any) => Subject;
+export default chch;

--- a/dist/chinchilla.js
+++ b/dist/chinchilla.js
@@ -3,33 +3,33 @@ const lodash_1 = require("lodash");
 const subject_1 = require("./chinchilla/subject");
 const config_1 = require("./chinchilla/config");
 const context_1 = require("./chinchilla/context");
-class chch {
-    static subject(objectsOrApp, model) {
-        // detach from existing Subject first before creating a new one..
-        objectsOrApp = subject_1.Subject.detachFromSubject(objectsOrApp);
-        return new subject_1.Subject(objectsOrApp, model);
+const cache_1 = require("./chinchilla/cache");
+let chch = (objectsOrApp, model) => {
+    // detach from existing Subject first before creating a new one..
+    objectsOrApp = subject_1.Subject.detachFromSubject(objectsOrApp);
+    return new subject_1.Subject(objectsOrApp, model);
+};
+chch['config'] = config_1.Config;
+chch['cache'] = cache_1.Cache;
+chch['new'] = (app, model, attrs = {}) => {
+    return lodash_1.merge({ '@context': `${config_1.Config.endpoints[app]}/context/${model}` }, attrs);
+};
+chch['contextUrl'] = (app, model) => {
+    return `${config_1.Config.endpoints[app]}/context/${model}`;
+};
+chch['context'] = (urlOrApp, model) => {
+    if (!model) {
+        // assume first param is the context url
+        return context_1.Context.get(urlOrApp).ready;
     }
-    static new(app, model, attrs = {}) {
-        return lodash_1.merge({ '@context': `${config_1.Config.endpoints[app]}/context/${model}` }, attrs);
+    else {
+        return context_1.Context.get(`${config_1.Config.endpoints[urlOrApp]}/context/${model}`).ready;
     }
-    static contextUrl(app, model) {
-        return `${config_1.Config.endpoints[app]}/context/${model}`;
-    }
-    static context(urlOrApp, model) {
-        if (!model) {
-            // assume first param is the context url
-            return context_1.Context.get(urlOrApp).ready;
-        }
-        else {
-            return context_1.Context.get(`${config_1.Config.endpoints[urlOrApp]}/context/${model}`).ready;
-        }
-    }
-}
-chch.config = config_1.Config;
+};
 // unfurl('pm, 'product', 'query', params) -> defaults to $c
 // unfurl('pm, 'product', '$c:query', params)
 // unfurl('pm, 'product', '$m:query_descendants', params)
-chch.unfurl = function (app, model, actionName, params) {
+chch['unfurl'] = (app, model, actionName, params) => {
     return new Promise(function (resolve, reject) {
         var page = 1;
         var result = { objects: [] };

--- a/dist/chinchilla/cache.d.ts
+++ b/dist/chinchilla/cache.d.ts
@@ -1,0 +1,11 @@
+export declare class Cache {
+    private static cacheSize;
+    private static cacheOrder;
+    private static cache;
+    static generateKey(type: string): string;
+    static add(key: string, obj: any): void;
+    static get(key: string): any;
+    static clear(): void;
+    private static capCache();
+    private static sliceCache(arr, size);
+}

--- a/dist/chinchilla/cache.js
+++ b/dist/chinchilla/cache.js
@@ -1,0 +1,42 @@
+"use strict";
+const lodash_1 = require("lodash");
+class Cache {
+    static generateKey(type) {
+        var hash = Math.random().toString(36).substr(2, 9);
+        return `${type}-${hash}`;
+    }
+    static add(key, obj) {
+        Cache.cache[key] = obj;
+        Cache.cacheOrder.push(key);
+        Cache.capCache();
+    }
+    static get(key) {
+        return Cache.cache[key];
+    }
+    static clear() {
+        Cache.cache = {};
+        Cache.cacheOrder = [];
+    }
+    static capCache() {
+        var sliced = Cache.sliceCache(Cache.cacheOrder, Cache.cacheSize);
+        lodash_1.each(sliced.remove, (key) => {
+            if (lodash_1.isFunction(Cache.cache[key]['destroy']))
+                Cache.cache[key].destroy();
+            delete Cache.cache[key];
+        });
+        Cache.cacheOrder = sliced.remain;
+    }
+    static sliceCache(arr, size) {
+        if (arr.length <= size)
+            return { remove: [], remain: arr };
+        var remain = arr.slice(size * -1);
+        return {
+            remain: remain,
+            remove: lodash_1.difference(arr, remain)
+        };
+    }
+}
+Cache.cacheSize = 250;
+Cache.cacheOrder = [];
+Cache.cache = {};
+exports.Cache = Cache;

--- a/dist/chinchilla/config.d.ts
+++ b/dist/chinchilla/config.d.ts
@@ -8,6 +8,7 @@ export declare class Config {
     static timestamp: number;
     static domain: string;
     static errorInterceptor: any;
+    static cookieTimeout: number;
     static setEndpoint(name: string, url: string): void;
     static setCookieDomain(domain: string): void;
     static setErrorInterceptor(fn: any): void;

--- a/dist/chinchilla/config.js
+++ b/dist/chinchilla/config.js
@@ -1,6 +1,6 @@
 "use strict";
 const Kekse = require("cookies-js");
-const context_1 = require("./context");
+const cache_1 = require("./cache");
 class Cookies {
     static get(...args) {
         return (typeof window !== undefined) ?
@@ -17,8 +17,7 @@ class Cookies {
 }
 exports.Cookies = Cookies;
 class Config {
-    // timestamp to be appended to every request
-    // will be the same for a session lifetime
+    // 1 month
     static setEndpoint(name, url) {
         Config.endpoints[name] = url;
     }
@@ -39,20 +38,21 @@ class Config {
     }
     static setSessionId(id) {
         Config.setValue('sessionId', id);
+        cache_1.Cache.clear();
     }
     static getSessionId() {
         return Config.getValue('sessionId');
     }
     static clearSessionId() {
         Config.clearValue('sessionId');
-        context_1.Context.clearCache();
+        cache_1.Cache.clear();
     }
     static getValue(name) {
         return Config[name] || Cookies.get(Config.cookieKey(name));
     }
     static setValue(name, value) {
         Config[name] = value;
-        Cookies.set(Config.cookieKey(name), value, { path: '/', domain: Config.domain, expires: 300 });
+        Cookies.set(Config.cookieKey(name), value, { path: '/', domain: Config.domain, expires: Config.cookieTimeout });
     }
     static clearValue(name) {
         Config[name] = undefined;
@@ -64,4 +64,5 @@ class Config {
 }
 Config.endpoints = {};
 Config.timestamp = Date.now() / 1000 | 0;
+Config.cookieTimeout = 30 * 24 * 60 * 60; // 1 month
 exports.Config = Config;

--- a/dist/chinchilla/context.d.ts
+++ b/dist/chinchilla/context.d.ts
@@ -22,14 +22,12 @@ export interface ContextProperty {
     validations?: any[];
 }
 export declare class Context {
-    static cache: {};
     ready: Promise<Context>;
     data: any;
     context: any;
     id: string;
     properties: any;
     constants: any;
-    static clearCache(): void;
     static get(contextUrl: string): Context;
     constructor(contextUrl: string);
     property(name: string): ContextProperty;

--- a/dist/chinchilla/context.js
+++ b/dist/chinchilla/context.js
@@ -2,6 +2,7 @@
 const lodash_1 = require("lodash");
 const request = require("superagent");
 const config_1 = require("./config");
+const cache_1 = require("./cache");
 class ContextAction {
     constructor(values = {}) {
         lodash_1.each(values, (value, key) => {
@@ -17,6 +18,18 @@ class ContextCollectionAction extends ContextAction {
 }
 exports.ContextCollectionAction = ContextCollectionAction;
 class Context {
+    static get(contextUrl) {
+        let key = lodash_1.first(contextUrl.split('?'));
+        let cached;
+        if (cached = cache_1.Cache.get(key)) {
+            return cached;
+        }
+        else {
+            let context = new Context(contextUrl);
+            cache_1.Cache.add(key, context);
+            return context;
+        }
+    }
     constructor(contextUrl) {
         this.ready = new Promise((resolve, reject) => {
             var req = request
@@ -41,19 +54,6 @@ class Context {
                 resolve(this);
             });
         });
-    }
-    static clearCache() {
-        Context.cache = {};
-    }
-    static get(contextUrl) {
-        var key = lodash_1.first(contextUrl.split('?'));
-        var cached;
-        if (cached = Context.cache[key]) {
-            return cached;
-        }
-        else {
-            return Context.cache[key] = new Context(contextUrl);
-        }
     }
     property(name) {
         return this.properties[name];
@@ -82,5 +82,4 @@ class Context {
         return new ContextCollectionAction(action);
     }
 }
-Context.cache = {};
 exports.Context = Context;

--- a/dist/chinchilla/subject.d.ts
+++ b/dist/chinchilla/subject.d.ts
@@ -18,6 +18,7 @@ export declare class Subject {
     readonly objects: any;
     readonly object: Object;
     readonly objectParams: Object;
+    destroy(): void;
     private addObjects(objects);
     private addObject(object);
     private moveAssociationReferences(object);

--- a/src/chinchilla.ts
+++ b/src/chinchilla.ts
@@ -2,77 +2,78 @@ import { merge, last, startsWith } from 'lodash'
 import { Subject } from './chinchilla/subject'
 import { Config } from './chinchilla/config'
 import { Context } from './chinchilla/context'
+import { Cache } from './chinchilla/cache'
 
-export default class chch {
-  public static subject(objectsOrApp, model?) {
-    // detach from existing Subject first before creating a new one..
-    objectsOrApp = Subject.detachFromSubject(objectsOrApp)
+let chch = (objectsOrApp, model?) => {
+  // detach from existing Subject first before creating a new one..
+  objectsOrApp = Subject.detachFromSubject(objectsOrApp)
 
-    return new Subject(objectsOrApp, model)
-  }
-
-  public static config = Config
-
-  public static new(app, model, attrs = {}) {
-    return merge(
-      { '@context': `${Config.endpoints[app]}/context/${model}` },
-      attrs
-    )
-  }
-
-  public static contextUrl(app, model) {
-    return `${Config.endpoints[app]}/context/${model}`
-  }
-
-  public static context(urlOrApp, model) {
-    if (!model) {
-      // assume first param is the context url
-      return Context.get(urlOrApp).ready
-    }
-    else {
-      return Context.get(`${Config.endpoints[urlOrApp]}/context/${model}`).ready
-    }
-  }
-
-  // unfurl('pm, 'product', 'query', params) -> defaults to $c
-  // unfurl('pm, 'product', '$c:query', params)
-  // unfurl('pm, 'product', '$m:query_descendants', params)
-  public static unfurl = function(app, model, actionName, params) {
-    return new Promise(function(resolve, reject) {
-      var page = 1;
-      var result = { objects: [] };
-      var subject = new Subject(app, model);
-      merge(params, { page: page });
-
-      var fetch = function() {
-        var action = last(actionName.match(/(\$[c|m]:)?(.*)/))
-        var promise;
-        if (startsWith(actionName, '$m')) {
-          promise = subject.$m(action, params)
-        }
-        else {
-          promise = subject.$c(action, params)
-        }
-
-        promise
-          .then(function(pageResult) {
-            page = page + 1;
-            merge(params, { page: page });
-            result.objects = result.objects.concat(pageResult.objects)
-
-            if ((page <= 100) && (page <= (pageResult.headers && pageResult.headers['x-total-pages'] || 0))) {
-              fetch();
-            }
-            else {
-              resolve(result);
-            }
-            return true;
-          }, function() {
-            reject(null);
-          });
-      };
-
-      fetch();
-    });
-  };
+  return new Subject(objectsOrApp, model)
 }
+
+chch['config'] = Config
+chch['cache']  = Cache
+
+chch['new'] = (app, model, attrs = {}) => {
+  return merge(
+    { '@context': `${Config.endpoints[app]}/context/${model}` },
+    attrs
+  )
+}
+
+chch['contextUrl'] = (app, model) => {
+  return `${Config.endpoints[app]}/context/${model}`
+}
+chch['context'] = (urlOrApp, model) => {
+  if (!model) {
+    // assume first param is the context url
+    return Context.get(urlOrApp).ready
+  }
+  else {
+    return Context.get(`${Config.endpoints[urlOrApp]}/context/${model}`).ready
+  }
+}
+
+// unfurl('pm, 'product', 'query', params) -> defaults to $c
+// unfurl('pm, 'product', '$c:query', params)
+// unfurl('pm, 'product', '$m:query_descendants', params)
+chch['unfurl'] = (app, model, actionName, params) => {
+  return new Promise(function(resolve, reject) {
+    var page = 1
+    var result = { objects: [] }
+    var subject = new Subject(app, model)
+    merge(params, { page: page })
+
+    var fetch = function() {
+      var action = last(actionName.match(/(\$[c|m]:)?(.*)/))
+      var promise
+      if (startsWith(actionName, '$m')) {
+        promise = subject.$m(action, params)
+      }
+      else {
+        promise = subject.$c(action, params)
+      }
+
+      promise
+        .then(function(pageResult) {
+          page = page + 1
+          merge(params, { page: page })
+          result.objects = result.objects.concat(pageResult.objects)
+
+          if ((page <= 100) && (page <= (pageResult.headers && pageResult.headers['x-total-pages'] || 0))) {
+            fetch()
+          }
+          else {
+            resolve(result)
+          }
+          return true
+        }, function() {
+          reject(null)
+        })
+    }
+
+    fetch()
+  })
+}
+
+export default chch

--- a/src/chinchilla/cache.ts
+++ b/src/chinchilla/cache.ts
@@ -1,0 +1,55 @@
+import { each, isFunction, difference } from 'lodash'
+import { Config } from './config'
+
+interface SlicedCache {
+    remove: any[],
+    remain: any[]
+}
+
+export class Cache {
+  private static cacheSize  = 250
+  private static cacheOrder = []
+  private static cache      = {}
+
+  static generateKey(type:string):string {
+    var hash = Math.random().toString(36).substr(2, 9)
+    return `${type}-${hash}`
+  }
+
+  static add(key:string, obj:any):void {
+    Cache.cache[key] = obj
+    Cache.cacheOrder.push(key)
+    Cache.capCache()
+  }
+
+  static get(key:string):any {
+    return Cache.cache[key]
+  }
+
+  static clear():void {
+    Cache.cache = {}
+    Cache.cacheOrder = []
+  }
+
+  private static capCache():void {
+    var sliced = Cache.sliceCache(Cache.cacheOrder, Cache.cacheSize)
+
+    each(sliced.remove, (key) => {
+      if (isFunction(Cache.cache[key]['destroy'])) Cache.cache[key].destroy()
+      delete Cache.cache[key]
+    })
+
+    Cache.cacheOrder = sliced.remain
+  }
+
+  private static sliceCache(arr, size):SlicedCache {
+    if (arr.length <= size) return { remove: [], remain: arr}
+
+    var remain = arr.slice(size * -1)
+
+    return {
+      remain: remain,
+      remove: difference(arr, remain)
+    }
+  }
+}

--- a/src/chinchilla/config.ts
+++ b/src/chinchilla/config.ts
@@ -1,6 +1,6 @@
 import * as Kekse from 'cookies-js'
 
-import { Context } from './context'
+import { Cache } from './cache'
 
 export class Cookies {
   static get(...args) {
@@ -22,9 +22,7 @@ export class Config {
   static timestamp = Date.now() / 1000 | 0
   static domain: string
   static errorInterceptor: any
-
-  // timestamp to be appended to every request
-  // will be the same for a session lifetime
+  static cookieTimeout = 30*24*60*60 // 1 month
 
   static setEndpoint(name: string, url: string): void {
     Config.endpoints[name] = url
@@ -52,6 +50,7 @@ export class Config {
 
   static setSessionId(id: string): void {
     Config.setValue('sessionId', id)
+    Cache.clear()
   }
 
   static getSessionId(): string {
@@ -60,7 +59,7 @@ export class Config {
 
   static clearSessionId(): void {
     Config.clearValue('sessionId')
-    Context.clearCache()
+    Cache.clear()
   }
 
   static getValue(name): string {
@@ -69,7 +68,7 @@ export class Config {
 
   static setValue(name, value): void {
     Config[name] = value
-    Cookies.set(Config.cookieKey(name), value, { path: '/', domain: Config.domain, expires: 300})
+    Cookies.set(Config.cookieKey(name), value, { path: '/', domain: Config.domain, expires: Config.cookieTimeout})
   }
 
   static clearValue(name): void {

--- a/src/chinchilla/context.ts
+++ b/src/chinchilla/context.ts
@@ -1,6 +1,7 @@
 import { each, first, isEmpty } from 'lodash'
 import * as request from 'superagent'
 import { Config } from './config'
+import { Cache } from './cache'
 
 export class ContextAction {
   public resource: string
@@ -32,8 +33,6 @@ export interface ContextProperty {
 }
 
 export class Context {
-  static cache = {}
-
   ready: Promise<Context>
   data: any
   context: any
@@ -41,19 +40,17 @@ export class Context {
   properties: any
   constants: any
 
-  static clearCache(): void {
-    Context.cache = {}
-  }
-
   static get(contextUrl: string): Context {
-    var key = first(contextUrl.split('?'))
-    var cached
+    let key = first(contextUrl.split('?'))
+    let cached
 
-    if (cached = Context.cache[key]) {
+    if (cached = Cache.get(key)) {
       return cached
     }
     else {
-      return Context.cache[key] = new Context(contextUrl)
+      let context = new Context(contextUrl)
+      Cache.add(key, context)
+      return context
     }
   }
 

--- a/src/es5.pack.ts
+++ b/src/es5.pack.ts
@@ -2,15 +2,8 @@
 
 import * as Promise from 'bluebird'
 import * as Cookies from 'cookies-js'
+import chch from './chinchilla'
 
 window['Promise'] = Promise
 window['Cookies'] = Cookies
-
-import chch from './chinchilla'
-
-window['chch'] = chch.subject
-window['chch'].new = chch.new
-window['chch'].context = chch.context
-window['chch'].config = chch.config
-window['chch'].contextUrl = chch.contextUrl
-window['chch'].unfurl = chch.unfurl
+window['chch']    = chch


### PR DESCRIPTION
* introduce global chinchilla cache which caches up to 250 contexts & subjects. if cache size is exceeded, then the oldest entries will be destroyed and removed from the cache
* TTL for cookies changed to 1 month
* default interface of chinchilla now is the same for es5 (browsers) and node/typescript